### PR TITLE
Add second dashboard variant

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -51,6 +51,9 @@ $govuk-assets-path: '/govuk/assets/';
 @import "overrides/dash-list";
 @import "overrides/summary-card";
 
+// Academies
+
+@import "components/dashboard";
 
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you

--- a/app/assets/sass/components/_dashboard.scss
+++ b/app/assets/sass/components/_dashboard.scss
@@ -1,0 +1,43 @@
+    // "colour":            govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30),
+    // "background-colour": govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90),
+    // "hover":             govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 80)
+
+
+.dashboard-project-right {
+  text-align: right;
+}
+
+.dashboard__filter-list {
+  border: 1px solid #979797;
+  padding: 12px;
+}
+
+.dashboard-project__small-text {
+  color: $govuk-secondary-text-colour;
+}
+
+.status-badge {
+  font-weight: 700;
+  padding: 0 10px;
+  display: inline-block;
+
+  &.status-badge__newly-assigned {
+    color: govuk-colour("green");
+    background-color: govuk-tint(govuk-colour("green"), 90);
+  }
+
+  &.status-badge__in-progress {
+    color: govuk-colour("blue");
+    background-color: govuk-tint(govuk-colour("blue"), 90);
+  }
+
+  &.status-badge__at-review {
+    color: #594E00;
+    background-color: #FEF5BB;
+  }
+
+  &.status-badge__awaiting-htb {
+    color: govuk-colour("purple");
+    background-color: govuk-tint(govuk-colour("purple"), 90);
+  }
+}

--- a/app/assets/sass/components/_dashboard.scss
+++ b/app/assets/sass/components/_dashboard.scss
@@ -7,6 +7,10 @@
   text-align: right;
 }
 
+.dashboard__urgent-projects {
+  background-color: govuk-tint(govuk-colour("light-grey"), 30);
+}
+
 .dashboard__filter-list {
   border: 1px solid #979797;
   padding: 12px;
@@ -20,6 +24,11 @@
   font-weight: 700;
   padding: 0 10px;
   display: inline-block;
+
+  &.status-badge__urgent {
+    color: govuk-colour("red");
+    background-color: govuk-tint(govuk-colour("red"), 90);
+  }
 
   &.status-badge__newly-assigned {
     color: govuk-colour("green");

--- a/app/data/transfers/dashboards/variant-1.json
+++ b/app/data/transfers/dashboards/variant-1.json
@@ -5,6 +5,7 @@
     "la": "Warrington LA",
     "status": "newly_assigned",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -13,6 +14,7 @@
     "la": "Warrington LA",
     "status": "newly_assigned",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
 
@@ -22,6 +24,7 @@
     "la": "Warrington LA",
     "status": "in_progress",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -30,6 +33,7 @@
     "la": "Warrington LA",
     "status": "in_progress",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -38,6 +42,7 @@
     "la": "Warrington LA",
     "status": "in_progress",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -46,6 +51,7 @@
     "la": "Warrington LA",
     "status": "in_progress",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
 
@@ -55,6 +61,7 @@
     "la": "Warrington LA",
     "status": "at_review",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -63,6 +70,7 @@
     "la": "Warrington LA",
     "status": "at_review",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -71,6 +79,7 @@
     "la": "Warrington LA",
     "status": "at_review",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
 
@@ -80,6 +89,7 @@
     "la": "Warrington LA",
     "status": "awaiting_htb",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   }
 ]

--- a/app/data/transfers/dashboards/variant-2.json
+++ b/app/data/transfers/dashboards/variant-2.json
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "newly_assigned",
+    "project": "a2b",
+    "reference": "AS_6759840",
+    "date": "12 January 2021"
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "project": "transfers",
+    "status": "newly_assigned",
+    "reference": "AS_6759840",
+    "date": "12 January 2021"
+  },
+
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "in_progress",
+    "reference": "AS_6759840",
+    "project": "change",
+    "date": "12 January 2021"
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "in_progress",
+    "reference": "AS_6759840",
+    "project": "concerns",
+    "date": "12 January 2021"
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "in_progress",
+    "reference": "AS_6759840",
+    "project": "transfers",
+    "date": "12 January 2021"
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "in_progress",
+    "reference": "AS_6759840",
+    "project": "transfers",
+    "date": "12 January 2021"
+  },
+
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "at_review",
+    "reference": "AS_6759840",
+    "project": "transfers",
+    "date": "12 January 2021"
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "at_review",
+    "reference": "AS_6759840",
+    "project": "transfers",
+    "date": "12 January 2021"
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "at_review",
+    "reference": "AS_6759840",
+    "project": "transfers",
+    "date": "12 January 2021"
+  },
+
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "awaiting_htb",
+    "reference": "AS_6759840",
+    "date": "12 January 2021"
+  }
+]

--- a/app/data/transfers/dashboards/variant-2.json
+++ b/app/data/transfers/dashboards/variant-2.json
@@ -4,8 +4,31 @@
     "joining": "Dynamics academy",
     "la": "Warrington LA",
     "status": "newly_assigned",
+    "project": "transfers",
+    "reference": "AS_6759840",
+    "daysUntilHTB": 2,
+    "date": "12 January 2021",
+    "urgent": true
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "newly_assigned",
     "project": "a2b",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
+    "date": "12 January 2021",
+    "urgent": true
+  },
+  {
+    "name": "St Wilfred's primary school",
+    "joining": "Dynamics academy",
+    "la": "Warrington LA",
+    "status": "newly_assigned",
+    "project": "a2b",
+    "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -15,6 +38,7 @@
     "project": "transfers",
     "status": "newly_assigned",
     "reference": "AS_6759840",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
 
@@ -25,6 +49,7 @@
     "status": "in_progress",
     "reference": "AS_6759840",
     "project": "change",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -34,6 +59,7 @@
     "status": "in_progress",
     "reference": "AS_6759840",
     "project": "concerns",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -43,6 +69,7 @@
     "status": "in_progress",
     "reference": "AS_6759840",
     "project": "transfers",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -52,6 +79,7 @@
     "status": "in_progress",
     "reference": "AS_6759840",
     "project": "transfers",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
 
@@ -62,6 +90,7 @@
     "status": "at_review",
     "reference": "AS_6759840",
     "project": "transfers",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -71,6 +100,7 @@
     "status": "at_review",
     "reference": "AS_6759840",
     "project": "transfers",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
   {
@@ -80,6 +110,7 @@
     "status": "at_review",
     "reference": "AS_6759840",
     "project": "transfers",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   },
 
@@ -89,6 +120,8 @@
     "la": "Warrington LA",
     "status": "awaiting_htb",
     "reference": "AS_6759840",
+    "project": "a2b",
+    "daysUntilHTB": 2,
     "date": "12 January 2021"
   }
 ]

--- a/app/routes/transfers/dashboard-routes.js
+++ b/app/routes/transfers/dashboard-routes.js
@@ -3,6 +3,14 @@ const fs = require('fs')
 const path = require('path')
 const { default: request } = require('sync-request')
 
+const removeUrgentProjects = (data) => {
+  return data.filter(project => !project.urgent)
+}
+
+const getUrgentProjects = (data) => {
+  return data.filter(project => project.urgent)
+}
+
 const filterDataByStatus = (data, statuses) => {
   filteredData = []
   statuses.forEach(status => {
@@ -44,6 +52,8 @@ module.exports = router => {
     let selectedStatuses = []
     let selectedProjectTypes = []
     let nameSearched = ""
+    let urgentProjects = getUrgentProjects(data);
+    data = removeUrgentProjects(data);
 
     if (req.query.status?.length > 0 && req.query.status != "_unchecked") {
       selectedStatuses = req.query.status
@@ -52,15 +62,23 @@ module.exports = router => {
 
     if (req.query.project?.length > 0 && req.query.project != "_unchecked") {
       selectedProjectTypes = req.query.project
+      urgentProjects = filterDataByProjectType(urgentProjects, req.query.project)
       data = filterDataByProjectType(data, req.query.project)
     }
 
     if (req.query['project-name-or-number']?.length > 0) {
       nameSearched = req.query['project-name-or-number']
+      urgentProjects = filterDataByNameOrId(urgentProjects, req.query['project-name-or-number'])
       data = filterDataByNameOrId(data, req.query['project-name-or-number'])
     }
 
     data = groupDataByStatus(data)
-    res.render(`transfers/dashboards/variant-${req.params.variantId}`, { projects: data, selectedStatuses, nameSearched, selectedProjectTypes })
+    res.render(`transfers/dashboards/variant-${req.params.variantId}`, {
+      projects: data,
+      urgentProjects,
+      selectedStatuses,
+      nameSearched,
+      selectedProjectTypes
+    })
   })
 }

--- a/app/routes/transfers/dashboard-routes.js
+++ b/app/routes/transfers/dashboard-routes.js
@@ -11,6 +11,14 @@ const filterDataByStatus = (data, statuses) => {
   return filteredData;
 }
 
+const filterDataByProjectType = (data, types) => {
+  filteredData = []
+  types.forEach(type => {
+    data.filter(project => project.project == type).forEach(project => filteredData.push(project))
+  })
+  return filteredData;
+}
+
 const filterDataByNameOrId = (data, nameOrId) => {
   nameOrId = nameOrId.toLowerCase()
 
@@ -32,13 +40,19 @@ const groupDataByStatus = (data) =>
 module.exports = router => {
   // Flush data when starting bulk action flow from the beginning
   router.get('/transfers/dashboard/:variantId', (req, res) => {
-    let data = require(path.join(__dirname, "../../data/transfers/dashboards/variant-1.json"))
+    let data = require(path.join(__dirname, `../../data/transfers/dashboards/variant-${req.params.variantId}.json`))
     let selectedStatuses = []
+    let selectedProjectTypes = []
     let nameSearched = ""
 
     if (req.query.status?.length > 0 && req.query.status != "_unchecked") {
       selectedStatuses = req.query.status
       data = filterDataByStatus(data, req.query.status)
+    }
+
+    if (req.query.project?.length > 0 && req.query.project != "_unchecked") {
+      selectedProjectTypes = req.query.project
+      data = filterDataByProjectType(data, req.query.project)
     }
 
     if (req.query['project-name-or-number']?.length > 0) {
@@ -47,6 +61,6 @@ module.exports = router => {
     }
 
     data = groupDataByStatus(data)
-    res.render(`transfers/dashboards/variant-${req.params.variantId}`, { projects: data, selectedStatuses, nameSearched })
+    res.render(`transfers/dashboards/variant-${req.params.variantId}`, { projects: data, selectedStatuses, nameSearched, selectedProjectTypes })
   })
 }

--- a/app/views/transfers/dashboards/variant-1.html
+++ b/app/views/transfers/dashboards/variant-1.html
@@ -1,13 +1,36 @@
 {% extends "layout.html" %}
 {% set navActive = "home" %}
 
+{% macro display_status_tag(status) %}
+  {% if status == 'newly_assigned' %}
+    <span class="govuk-body status-badge status-badge__newly-assigned">NEWLY ASSIGNED</span>
+  {% elif status == 'in_progress' %}
+    <span class="govuk-body status-badge status-badge__in-progress">IN PROGRESS</span>
+  {% elif status == 'at_review' %}
+    <span class="govuk-body status-badge status-badge__at-review">AT REVIEW</span>
+  {% elif status == 'awaiting_htb' %}
+    <span class="govuk-body status-badge status-badge__awaiting-htb">SUBMITTED</span>
+  {% endif %}
+{% endmacro %}
+
 {% macro projects_for_field(data, heading, field) %}
   <h2 class="govuk-heading-l">{{ heading }} ({{ data[field].length }})</h2>
   {% for project in data[field] %}
-    <p>{{ project.name }} | {{ project.status }}</p>
-    <p>{{project.joining }} | {{ project.la }}</p>
-    <p>{{project.date }} | {{ project.reference }}</p>
-    <hr />
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m">
+          <a class="govuk-link" href="#">{{project.name}}</a>
+        </h3>
+        <p class="govuk-body govuk-!-margin-bottom-1">Application to join {{project.joining}}</p>
+        <p class="govuk-body-s dashboard-project__small-text">{{project.la}}</p>
+      </div>
+      <div class="govuk-grid-column-one-third dashboard-project-right">
+        {{ display_status_tag(project.status) }}
+        <p class="govuk-body govuk-!-margin-bottom-1">{{project.reference}}</p>
+        <p class="govuk-body-s dashboard-project__small-text">{{project.date}}</p>
+      </div>
+    </div>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
   {% endfor %}
 {% endmacro %}
 
@@ -24,12 +47,24 @@
 </div>
 
 <div class="govuk-width-container"><br>
-  <h1 class="govuk-heading-xl">Dashboard</h1>
+  <h1 class="govuk-heading-xl">Academy Transfers</h1>
 </div>
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body">
+      Set up a new academy transfer project
+    </p>
+    <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      Start a new transfer project
+    </a>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+<div class="govuk-grid-row govuk-!-margin-top-2">
   <div class="govuk-grid-column-one-third">
     <form method="GET">
-      <div class="govuk-form-group">
+      <div class="govuk-form-group dashboard__filter-list">
+        <h2 class="govuk-heading-l">Filter</h2>
         <button class="govuk-button" data-module="govuk-button" type="submit">
           Apply filters
         </button>

--- a/app/views/transfers/dashboards/variant-1.html
+++ b/app/views/transfers/dashboards/variant-1.html
@@ -27,7 +27,7 @@
       <div class="govuk-grid-column-one-third dashboard-project-right">
         {{ display_status_tag(project.status) }}
         <p class="govuk-body govuk-!-margin-bottom-1">{{project.reference}}</p>
-        <p class="govuk-body-s dashboard-project__small-text">{{project.date}}</p>
+        <p class="govuk-body-s dashboard-project__small-text">{{project.daysUntilHTB}} days until HTB</p>
       </div>
     </div>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">

--- a/app/views/transfers/dashboards/variant-1.html
+++ b/app/views/transfers/dashboards/variant-1.html
@@ -54,7 +54,7 @@
     <p class="govuk-body">
       Set up a new academy transfer project
     </p>
-    <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+    <a href="#" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
       Start a new transfer project
     </a>
   </div>

--- a/app/views/transfers/dashboards/variant-2.html
+++ b/app/views/transfers/dashboards/variant-2.html
@@ -1,0 +1,213 @@
+{% extends "layout.html" %}
+{% set navActive = "home" %}
+
+{% macro display_project_info(project_type) %}
+  {% if project_type == 'a2b' %}
+    Application to become an academy
+  {% elif project_type == 'transfers' %}
+    Application to join Dynamics Academy
+  {% elif project_type == 'change' %}
+    Application to change age range
+  {% elif project_type == 'concerns' %}
+    Concerns on financial deficit
+  {% endif %}
+{% endmacro %}
+
+{% macro display_project(data) %}
+  <p>{{ data.name }} | {{ data.status }}</p>
+  <p>{{ data.joining }} | {{ data.la }}</p>
+  <p>{{ data.date }} | {{ data.reference }}</p>
+  <p>{{ display_project_info(data.project) }}</p>
+  <hr />
+{% endmacro %}
+
+{% macro projects_for_field(data, heading, field) %}
+  <h2 class="govuk-heading-l">{{ heading }} ({{ data[field].length }})</h2>
+  {% for project in data[field] %}
+    {{ display_project(project) }}
+  {% endfor %}
+{% endmacro %}
+
+
+
+{% block content %}
+
+<div class="govuk-breadcrumbs ">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="dashboard.html">Dashboard</a>
+    </li>
+  </ol>
+</div>
+
+<div class="govuk-width-container"><br>
+  <h1 class="govuk-heading-xl">Dashboard</h1>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <form method="GET">
+      <div class="govuk-form-group">
+        <button class="govuk-button" data-module="govuk-button" type="submit">
+          Apply filters
+        </button>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <label for="project-name-or-number"><legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Project number or name
+            </legend></label>
+            <input 
+              class="govuk-input" 
+              id="project-name-or-number" 
+              name="project-name-or-number" 
+              type="text"
+              {% if nameSearched %} value={{nameSearched}} {% endif %}
+            >
+          </fieldset>
+        </div>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Project
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small">
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="project" 
+                  name="project" 
+                  type="checkbox" 
+                  value="a2b"
+                  {% if selectedProjectTypes.includes("a2b") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="project">
+                  Apply to Become
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="project-2" 
+                  name="project" 
+                  type="checkbox" 
+                  value="transfers"
+                  {% if selectedProjectTypes.includes("transfers") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="project-2">
+                  Transfers
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="project-3" 
+                  name="project" 
+                  type="checkbox" 
+                  value="change"
+                  {% if selectedProjectTypes.includes("change") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="project-3">
+                  Significant change
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="project-4" 
+                  name="project" 
+                  type="checkbox" 
+                  value="concerns"
+                  {% if selectedProjectTypes.includes("concerns") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="project-4">
+                  Concerns
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Status
+            </legend>
+            <div class="govuk-checkboxes govuk-checkboxes--small">
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="status" 
+                  name="status" 
+                  type="checkbox" 
+                  value="newly_assigned"
+                  {% if selectedStatuses.includes("newly_assigned") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="status">
+                  Newly assigned
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="status-2" 
+                  name="status" 
+                  type="checkbox" 
+                  value="in_progress"
+                  {% if selectedStatuses.includes("in_progress") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="status-2">
+                  In progress
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="status-3" 
+                  name="status" 
+                  type="checkbox" 
+                  value="at_review"
+                  {% if selectedStatuses.includes("at_review") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="status-3">
+                  At review
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input 
+                  class="govuk-checkboxes__input" 
+                  id="status-4" 
+                  name="status" 
+                  type="checkbox" 
+                  value="awaiting_htb"
+                  {% if selectedStatuses.includes("awaiting_htb") %} checked {% endif %}
+                >
+                <label class="govuk-label govuk-checkboxes__label" for="status-4">
+                  Awaiting HTB
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    {% if projects.newly_assigned %}
+      {{ projects_for_field(projects, 'Newly assigned to me', 'newly_assigned')}}
+    {% endif %}
+
+    {% if projects.in_progress %}
+      {{ projects_for_field(projects, 'In progress', 'in_progress')}}
+    {% endif %}
+
+    {% if projects.at_review %}
+      {{ projects_for_field(projects, 'At review', 'at_review')}}
+    {% endif %}
+
+    {% if projects.awaiting_htb %}
+      {{ projects_for_field(projects, 'Awaiting HTB', 'awaiting_htb')}}
+    {% endif %}
+  </div>
+
+</div>
+
+{% endblock %}

--- a/app/views/transfers/dashboards/variant-2.html
+++ b/app/views/transfers/dashboards/variant-2.html
@@ -87,20 +87,6 @@
         </button>
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
-            <label for="project-name-or-number"><legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              Project number or name
-            </legend></label>
-            <input 
-              class="govuk-input" 
-              id="project-name-or-number" 
-              name="project-name-or-number" 
-              type="text"
-              {% if nameSearched %} value={{nameSearched}} {% endif %}
-            >
-          </fieldset>
-        </div>
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               Project
             </legend>
@@ -226,6 +212,38 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
+    <form method="GET">
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l">Search by project number, school or trust name</h2>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-three-quarters">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <input 
+                  class="govuk-input" 
+                  id="project-name-or-number" 
+                  name="project-name-or-number" 
+                  type="text"
+                  {% if nameSearched %} value={{nameSearched}} {% endif %}
+                >
+              </fieldset>
+            </div>
+          </div>
+          <div class="govuk-grid-column-one-quarter">
+            <button class="govuk-button" data-module="govuk-button" type="submit">
+              Apply filters
+            </button>
+          </div>
+        </div>
+        <p class="govuk-body">
+          Set up a new academy transfer project
+        </p>
+        <a href="#" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+          Start a new transfer project
+        </a>
+      </div>
+    </form>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full dashboard__urgent-projects">
         {% if urgentProjects.length > 0 %}

--- a/app/views/transfers/dashboards/variant-2.html
+++ b/app/views/transfers/dashboards/variant-2.html
@@ -13,22 +13,56 @@
   {% endif %}
 {% endmacro %}
 
-{% macro display_project(data) %}
-  <p>{{ data.name }} | {{ data.status }}</p>
-  <p>{{ data.joining }} | {{ data.la }}</p>
-  <p>{{ data.date }} | {{ data.reference }}</p>
-  <p>{{ display_project_info(data.project) }}</p>
-  <hr />
+{% macro project_type_to_text(project_type) %}
+  {% if project_type == 'a2b' %}
+    Apply to become
+  {% elif project_type == 'transfers' %}
+    Transfers
+  {% elif project_type == 'change' %}
+    Significant change
+  {% elif project_type == 'concerns' %}
+    Case concerns
+  {% endif %}
+{% endmacro %}
+
+{% macro display_status_tag(project) %}
+  {% if project.urgent %}
+    <span class="govuk-body status-badge status-badge__urgent">URGENT</span>
+  {% elif project.status == 'newly_assigned' %}
+    <span class="govuk-body status-badge status-badge__newly-assigned">NEWLY ASSIGNED</span>
+  {% elif project.status == 'in_progress' %}
+    <span class="govuk-body status-badge status-badge__in-progress">IN PROGRESS</span>
+  {% elif project.status == 'at_review' %}
+    <span class="govuk-body status-badge status-badge__at-review">AT REVIEW</span>
+  {% elif project.status == 'awaiting_htb' %}
+    <span class="govuk-body status-badge status-badge__awaiting-htb">SUBMITTED</span>
+  {% endif %}
+{% endmacro %}
+
+{% macro displayProject(project) %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m">
+        <a class="govuk-link" href="#">{{project.name}}</a>
+      </h3>
+      <p class="govuk-body govuk-!-margin-bottom-1">{{ display_project_info(project.project) }}</p>
+      <p class="govuk-body-s dashboard-project__small-text">{{ project_type_to_text(project.project) }}</p>
+    </div>
+    <div class="govuk-grid-column-one-third dashboard-project-right">
+      {{ display_status_tag(project) }}
+      <p class="govuk-body govuk-!-margin-bottom-1">{{project.reference}}</p>
+      <p class="govuk-body-s dashboard-project__small-text">{{project.daysUntilHTB}} days until HTB</p>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-top-0">
 {% endmacro %}
 
 {% macro projects_for_field(data, heading, field) %}
   <h2 class="govuk-heading-l">{{ heading }} ({{ data[field].length }})</h2>
   {% for project in data[field] %}
-    {{ display_project(project) }}
+    {{ displayProject(project) }}
   {% endfor %}
 {% endmacro %}
-
-
 
 {% block content %}
 
@@ -46,7 +80,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <form method="GET">
-      <div class="govuk-form-group">
+      <div class="govuk-form-group dashboard__filter-list">
+        <h2 class="govuk-heading-l">Filter</h2>
         <button class="govuk-button" data-module="govuk-button" type="submit">
           Apply filters
         </button>
@@ -191,21 +226,40 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    {% if projects.newly_assigned %}
-      {{ projects_for_field(projects, 'Newly assigned to me', 'newly_assigned')}}
-    {% endif %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full dashboard__urgent-projects">
+        {% if urgentProjects.length > 0 %}
+          <h2 class="govuk-heading-l">Needs urgent attention ({{ urgentProjects.length }})</h2>
+          {% for project in urgentProjects %}
+            {{ displayProject(project) }}
+          {% endfor %}
+        {% endif %}
+      </div>
+    </div>
 
-    {% if projects.in_progress %}
-      {{ projects_for_field(projects, 'In progress', 'in_progress')}}
-    {% endif %}
+    <div class="govuk-!-margin-top-5">
+      {% if projects.newly_assigned %}
+        {{ projects_for_field(projects, 'Newly assigned to me', 'newly_assigned')}}
+      {% endif %}
+    </div>
 
-    {% if projects.at_review %}
-      {{ projects_for_field(projects, 'At review', 'at_review')}}
-    {% endif %}
+    <div class="govuk-!-margin-top-5">
+      {% if projects.in_progress %}
+        {{ projects_for_field(projects, 'In progress', 'in_progress')}}
+      {% endif %}
+    </div>
 
-    {% if projects.awaiting_htb %}
-      {{ projects_for_field(projects, 'Awaiting HTB', 'awaiting_htb')}}
-    {% endif %}
+    <div class="govuk-!-margin-top-5">
+      {% if projects.at_review %}
+        {{ projects_for_field(projects, 'At review', 'at_review')}}
+      {% endif %}
+    </div>
+
+    <div class="govuk-!-margin-top-5">
+      {% if projects.awaiting_htb %}
+        {{ projects_for_field(projects, 'Awaiting HTB', 'awaiting_htb')}}
+      {% endif %}
+    </div>
   </div>
 
 </div>


### PR DESCRIPTION
# What does this PR Do?

- Adds an additional dashboard variant that supports filtering by project type (instead of selecting tabs)
- Styles the dashboards

Dashboard Variant 1 (Now with styling)
![image](https://user-images.githubusercontent.com/976254/107661307-142ce680-6c81-11eb-8c5b-e2d6179056c5.png)

Dashboard Variant 2
![image](https://user-images.githubusercontent.com/976254/107661348-1ee77b80-6c81-11eb-9910-30e8604cfa3d.png)
