### PR TITLE
Use GOV.UK Tags for dashboards

### DIFF
--- a/app/assets/sass/components/_dashboard.scss
+++ b/app/assets/sass/components/_dashboard.scss
@@ -19,34 +19,3 @@
 .dashboard-project__small-text {
   color: $govuk-secondary-text-colour;
 }
-
-.status-badge {
-  font-weight: 700;
-  padding: 0 10px;
-  display: inline-block;
-
-  &.status-badge__urgent {
-    color: govuk-colour("red");
-    background-color: govuk-tint(govuk-colour("red"), 90);
-  }
-
-  &.status-badge__newly-assigned {
-    color: govuk-colour("green");
-    background-color: govuk-tint(govuk-colour("green"), 90);
-  }
-
-  &.status-badge__in-progress {
-    color: govuk-colour("blue");
-    background-color: govuk-tint(govuk-colour("blue"), 90);
-  }
-
-  &.status-badge__at-review {
-    color: #594E00;
-    background-color: #FEF5BB;
-  }
-
-  &.status-badge__awaiting-htb {
-    color: govuk-colour("purple");
-    background-color: govuk-tint(govuk-colour("purple"), 90);
-  }
-}

--- a/app/views/transfers/dashboards/variant-1.html
+++ b/app/views/transfers/dashboards/variant-1.html
@@ -3,13 +3,13 @@
 
 {% macro display_status_tag(status) %}
   {% if status == 'newly_assigned' %}
-    <span class="govuk-body status-badge status-badge__newly-assigned">NEWLY ASSIGNED</span>
+    <span class="govuk-tag govuk-tag--green">NEWLY ASSIGNED</span>
   {% elif status == 'in_progress' %}
-    <span class="govuk-body status-badge status-badge__in-progress">IN PROGRESS</span>
+    <span class="govuk-tag govuk-tag--blue">IN PROGRESS</span>
   {% elif status == 'at_review' %}
-    <span class="govuk-body status-badge status-badge__at-review">AT REVIEW</span>
+    <span class="govuk-tag govuk-tag--yellow">AT REVIEW</span>
   {% elif status == 'awaiting_htb' %}
-    <span class="govuk-body status-badge status-badge__awaiting-htb">SUBMITTED</span>
+    <span class="govuk-tag govuk-tag--purple">SUBMITTED</span>
   {% endif %}
 {% endmacro %}
 

--- a/app/views/transfers/dashboards/variant-2.html
+++ b/app/views/transfers/dashboards/variant-2.html
@@ -27,15 +27,15 @@
 
 {% macro display_status_tag(project) %}
   {% if project.urgent %}
-    <span class="govuk-body status-badge status-badge__urgent">URGENT</span>
+    <span class="govuk-tag govuk-tag--red">URGENT</span>
   {% elif project.status == 'newly_assigned' %}
-    <span class="govuk-body status-badge status-badge__newly-assigned">NEWLY ASSIGNED</span>
+    <span class="govuk-tag govuk-tag--green">NEWLY ASSIGNED</span>
   {% elif project.status == 'in_progress' %}
-    <span class="govuk-body status-badge status-badge__in-progress">IN PROGRESS</span>
+    <span class="govuk-tag govuk-tag--blue">IN PROGRESS</span>
   {% elif project.status == 'at_review' %}
-    <span class="govuk-body status-badge status-badge__at-review">AT REVIEW</span>
+    <span class="govuk-tag govuk-tag--yellow">AT REVIEW</span>
   {% elif project.status == 'awaiting_htb' %}
-    <span class="govuk-body status-badge status-badge__awaiting-htb">SUBMITTED</span>
+    <span class="govuk-tag govuk-tag--purple">SUBMITTED</span>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
This PR brings the status tags on the dashboards inline with the GOV.UK Design system﻿
