### PR TITLE
Add accessible autocomplete to incoming/outgoing trust pages

### DIFF
--- a/app/filters/trusts.js
+++ b/app/filters/trusts.js
@@ -34,6 +34,15 @@ filters.filterTrustsBySearchString = (trusts, searchString) => {
   })
 }
 
+filters.trustsForAutocomplete = (trusts) => {
+  return trusts.map(
+    trust => ({
+      id: trust.id,
+      searchString: `${trust.trust_name}, ${trust.trust_reference_number}, ${trust.companies_house_number}`
+    })
+  )
+}
+
 filters.getTrustById = (trusts, id) => {
   return trusts.find(trust => trust.id === id)
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -3,4 +3,24 @@ const router = express.Router()
 
 require('./routes/transfers/dashboard-routes')(router)
 
+router.get('/transfers/outgoing-trust-search', (req, res) => {
+  if (req.query['outgoing-trust-id']) {
+    req.session.data['outgoing-trust-id'] = req.query['outgoing-trust-id']
+    req.session.data['autocompleted-outgoing-trust-id'] = true
+    res.redirect('/transfers/trust-details')
+  } else {
+    res.render('transfers/outgoing-trust-search')
+  }
+})
+
+router.get('/transfers/incoming-trust-search', (req, res) => {
+  if (req.query['incoming-trust-id']) {
+    req.session.data['incoming-trust-id'] = req.query['incoming-trust-id']
+    req.session.data['autocompleted-incoming-trust-id'] = true
+    res.redirect('/transfers/summary')
+  } else {
+    res.render('transfers/incoming-trust-search')
+  }
+})
+
 module.exports = router

--- a/app/views/transfers/incoming.html
+++ b/app/views/transfers/incoming.html
@@ -9,7 +9,7 @@
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <form method="get" action="/transfers/incoming-trust-search.html">
+                <form method="get" action="/transfers/incoming-trust-search">
                     <div class="govuk-form-group">
                         <fieldset class="govuk-fieldset" aria-required="true">
                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -22,6 +22,7 @@
                             <input class="govuk-input" name="incoming-trust-search-query"
                                    id="incoming-trust-search-query"
                                    type="text" aria-describedby="incoming-trust-search-query-hint">
+                            <div id="autocomplete-container"></div>
                         </fieldset>
                     </div>
                     <button class="govuk-button" type="submit">Submit</button>
@@ -29,4 +30,31 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block pageScripts %}
+    <script type="text/javascript" src="/public/javascripts/autocomplete.min.js"></script>
+    {# <link rel="stylesheet" href="/public/stylesheets/autocomplete.min.css"/> #}
+    <script>
+      try {
+        const trusts = {{ data["trusts"] | trustsForAutocomplete | dump | safe }}
+        const trustNames = trusts.map(trust => trust.searchString)
+        const $input = document.getElementById('incoming-trust-search-query')
+
+        accessibleAutocomplete({
+          element: document.querySelector('#autocomplete-container'),
+          id: $input.id,
+          name: $input.name,
+          source: trustNames,
+          confirmOnBlur: false,
+          onConfirm: (selected) => ($input.value = selected ? trusts.find(item => item.searchString === selected).id : '')
+        })
+
+        $input.id = `old-${$input.id}`
+        $input.name = 'incoming-trust-id'
+        $input.type = 'hidden'
+      } catch {
+        console.log('Autocomplete failed to initialize...')
+      }
+    </script>
 {% endblock %}

--- a/app/views/transfers/summary.html
+++ b/app/views/transfers/summary.html
@@ -2,8 +2,13 @@
 {% set navActive = "home" %}
 
 {% block beforeContent %}
+    {% if data['autocompleted-incoming-trust-id'] %}
+    <a class="govuk-back-link"
+       href="/transfers/incoming.html">Back</a>
+    {% else %}
     <a class="govuk-back-link"
        href="incoming-trust-search.html?incoming-trust-search-query{{ data['incoming-trust-search-query'] }}">Back</a>
+    {% endif %}
 {% endblock %}
 
 {% set outgoingTrust = data['trusts'] | getTrustById(data['outgoing-trust-id']) %}

--- a/app/views/transfers/trust-details.html
+++ b/app/views/transfers/trust-details.html
@@ -2,8 +2,13 @@
 {% set navActive = "home" %}
 
 {% block beforeContent %}
+    {% if data['autocompleted-outgoing-trust-id'] %}
+    <a class="govuk-back-link"
+       href="/transfers/trust-name.html">Back</a>
+    {% else %}
     <a class="govuk-back-link"
        href="/transfers/outgoing-trust-search.html?outgoing-trust-search-query={{ data['outgoing-trust-search-query'] }}">Back</a>
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/transfers/trust-name.html
+++ b/app/views/transfers/trust-name.html
@@ -9,7 +9,7 @@
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <form method="get" action="/transfers/outgoing-trust-search.html">
+                <form method="get" action="/transfers/outgoing-trust-search">
                     <div class="govuk-form-group">
                         <fieldset class="govuk-fieldset" aria-required="true">
                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -24,6 +24,8 @@
                             <input class="govuk-input" name="outgoing-trust-search-query"
                                    id="outgoing-trust-search-query"
                                    type="text" aria-describedby="outgoing-trust-search-query-hint">
+                            <div id="autocomplete-container">
+                            </div>
                         </fieldset>
                     </div>
                     <button class="govuk-button" type="submit">Submit</button>
@@ -31,4 +33,31 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block pageScripts %}
+    <script type="text/javascript" src="/public/javascripts/autocomplete.min.js"></script>
+    {# <link rel="stylesheet" href="/public/stylesheets/autocomplete.min.css"/> #}
+    <script>
+      try {
+        const trusts = {{ data["trusts"] | trustsForAutocomplete | dump | safe }}
+        const trustNames = trusts.map(trust => trust.searchString)
+        const $input = document.getElementById('outgoing-trust-search-query')
+
+        accessibleAutocomplete({
+          element: document.querySelector('#autocomplete-container'),
+          id: $input.id,
+          name: $input.name,
+          source: trustNames,
+          confirmOnBlur: false,
+          onConfirm: (selected) => ($input.value = selected ? trusts.find(item => item.searchString === selected).id : '')
+        })
+
+        $input.id = `old-${$input.id}`
+        $input.name = 'outgoing-trust-id'
+        $input.type = 'hidden'
+      } catch {
+        console.log('Autocomplete failed to initialize...')
+      }
+    </script>
 {% endblock %}


### PR DESCRIPTION
## Context

To improve the usability of the prototype, we want to include autocomplete on the pages for searching for an incoming/outgoing trust

## Changes

- Adds the accessible autocomplete into the trust-name page and the incoming page
- Updates the back links to support correct back navigation in the case of choosing the autocomplete result