### PR TITLE
Add tables to key stage performance

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -124,10 +124,19 @@
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m">Version 2</h3>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><a href="./version-2/dashboard-home" class="govuk-link">Landing page</a></li>
-    </ul>
+    <p class="govuk-body">
+      <a href="./version-2/dashboard-home" class="govuk-link">Sprint 3</a>
+    </p>
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">Version 3</h3>
+    <p class="govuk-body">
+      <a href="./version-3/dashboard-home" class="govuk-link">Sprint 4</a>
+    </p>
+  </div>
+</div>
+  
 </div>
 
 {% endblock %}

--- a/app/views/version-2/pre-htb/school-1/key-stage-performance-tables.html
+++ b/app/views/version-2/pre-htb/school-1/key-stage-performance-tables.html
@@ -57,7 +57,7 @@
                         School name
                     </dt>
                     <dd class="govuk-summary-list__value govuk-summary-list__value--width-50">
-                        <span class="empty">Empty</span>
+                        <p class="govuk-body">Godmanchester Community Academy</p>
                     </dd>
                 </div>
 
@@ -629,6 +629,394 @@
             </div>
 
             </form>           
+        </div>
+    </div>
+
+    <div class="govuk-grid-row govuk-!-margin-top-6">
+        <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-6">
+            {{ govukTable({
+                caption: "Key stage 1 – Godmanchester Community Academy",
+                captionClasses: "govuk-table__caption--m",
+                firstCellIsHeader: true,
+                head: [
+                    {
+                        text: "Subjects"
+                    },
+                    {
+                        text: "2016",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2017",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018 national mean average percentage",
+                        format: "numeric",
+                        classes: 'govuk-!-width-one-quarter'
+                    }
+                ],
+                rows: [
+                    [
+                        {
+                            text: "Reading"
+                        },
+                        {
+                            text: "87%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "81%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "83%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "75%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Writing"
+                        },
+                        {
+                            text: "92%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "91%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "85%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "70%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Maths"
+                        },
+                        {
+                            text: "89%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "92%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "86%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "76%",
+                            format: "numeric"
+                        }
+                    ]
+                ]
+                }) }}
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-6">
+            {{ govukTable({
+                caption: "Key stage 1 – Godmanchester Bridge Academy",
+                captionClasses: "govuk-table__caption--m",
+                firstCellIsHeader: true,
+                head: [
+                    {
+                        text: "Subjects"
+                    },
+                    {
+                        text: "2016",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2017",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018 national mean average percentage",
+                        format: "numeric",
+                        classes: 'govuk-!-width-one-quarter'
+                    }
+                ],
+                rows: [
+                    [
+                        {
+                            text: "Reading"
+                        },
+                        {
+                            text: "100%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "80%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "75%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "75%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Writing"
+                        },
+                        {
+                            text: "100%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "90%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "85%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "70%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Maths"
+                        },
+                        {
+                            text: "0%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "81%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "96%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "76%",
+                            format: "numeric"
+                        }
+                    ]
+                ]
+                }) }}
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-6">
+            {{ govukTable({
+                caption: "Key stage 1 – Gorefield primary school",
+                captionClasses: "govuk-table__caption--m",
+                firstCellIsHeader: true,
+                head: [
+                    {
+                        text: "Subjects"
+                    },
+                    {
+                        text: "2016",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2017",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018 national mean average percentage",
+                        format: "numeric",
+                        classes: 'govuk-!-width-one-quarter'
+                    }
+                ],
+                rows: [
+                    [
+                        {
+                            text: "Reading"
+                        },
+                        {
+                            text: "81%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "0%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "73%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "75%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Writing"
+                        },
+                        {
+                            text: "81%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "0%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "73%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "70%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Maths"
+                        },
+                        {
+                            text: "94%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "0%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "94%",
+                            format: "numeric"
+                        },
+                        {
+                            text: "76%",
+                            format: "numeric"
+                        }
+                    ]
+                ]
+                }) }}
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-6">
+            {{ govukTable({
+                caption: "Key stage 1 – 0",
+                captionClasses: "govuk-table__caption--m",
+                firstCellIsHeader: true,
+                head: [
+                    {
+                        text: "Subjects"
+                    },
+                    {
+                        text: "2016",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2017",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018",
+                        format: "numeric"
+                    },
+                    {
+                        text: "2018 national mean average percentage",
+                        format: "numeric",
+                        classes: 'govuk-!-width-one-quarter'
+                    }
+                ],
+                rows: [
+                    [
+                        {
+                            text: "Reading"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "75%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Writing"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "70%",
+                            format: "numeric"
+                        }
+                    ],
+                    [
+                        {
+                            text: "Maths"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "?",
+                            format: "numeric"
+                        },
+                        {
+                            text: "76%",
+                            format: "numeric"
+                        }
+                    ]
+                ]
+                }) }}
         </div>
     </div>
 

--- a/app/views/version-3/pre-htb/school-1/st-wilfreds-ps-reference-data.html
+++ b/app/views/version-3/pre-htb/school-1/st-wilfreds-ps-reference-data.html
@@ -4,7 +4,7 @@
 
 {% block beforeContent %}
   {% include "version-2/includes/phase-banner.html" %}
-  <a class="govuk-back-link" href="/transfers/dashboard/1">Back to transfer projects</a>
+  <a class="govuk-back-link" href="/version-3/dashboard-home">Back to transfer projects</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/version-3/pre-htb/school-1/st-wilfreds-ps.html
+++ b/app/views/version-3/pre-htb/school-1/st-wilfreds-ps.html
@@ -4,7 +4,7 @@
 
 {% block beforeContent %}
   {% include "version-2/includes/phase-banner.html" %}
-  <a class="govuk-back-link" href="/transfers/dashboard/1">Back to transfer projects</a>
+  <a class="govuk-back-link" href="/version-3/dashboard-home">Back to transfer projects</a>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
- updated key stage performance page with tables instead of a summary list type for KS1 data
- updated landing page with version 3 link
- created a version 3 for the redesign look of task list