### PR TITLE
Update new project name heading structure

### DIFF
--- a/app/assets/sass/version-2/_application-card.scss
+++ b/app/assets/sass/version-2/_application-card.scss
@@ -15,7 +15,10 @@
 }
 
 .app-application-card .app-application-card--project-info {
-  width: 60%;
+  width: 100%;
+  @include govuk-media-query($from: desktop, $and: '(orientation: landscape)') {
+    width: 60%;
+  }
 }
 
 .app-application-card .app-application-card--statuses {

--- a/app/views/version-4/dashboard-home.html
+++ b/app/views/version-4/dashboard-home.html
@@ -40,11 +40,11 @@
         {% set outgoingTrust = data['trusts'] | getTrustById(data['outgoing-trust-id']) %}
         <div class="app-application-card">
           <div class="app-application-card--project-info">
-            <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+            <h4 class="govuk-heading-m govuk-!-margin-bottom-2">
               <a class="govuk-link govuk-!-margin-right-1" href="./pre-htb/school-1/st-wilfreds-ps">
                 {{ project.project_reference }}
               </a>
-            </h3>
+            </h4>
             <p class="govuk-body govuk-!-margin-bottom-1">
               <span class="govuk-!-font-weight-bold govuk-!-display-inline">
                 Outgoing trust:
@@ -58,14 +58,16 @@
               Moordown St John's Church Of England Primary School
             </p>
           </div>
-          {# <div class="app-application-card--statuses">
+          <!--Disabling statuses for the time being until we learn more about the needs to use it
+          <div class="app-application-card--statuses">
             <span class="govuk-tag govuk-tag--orange">
               SAT
             </span>
             <span class="govuk-tag govuk-tag--green">
               SW
             </span>
-          </div> #}
+          </div>
+          <!-->
         </div>
       {% endfor %}
 

--- a/app/views/version-4/includes/attachment.html
+++ b/app/views/version-4/includes/attachment.html
@@ -9,7 +9,7 @@
     <div class="app-c-attachment__details">
         <h2 class="app-c-attachment__title">
             <a class="govuk-link app-c-attachment__link" target="_self" href="#">
-                SW-MAT-10000001 – AB template
+                SW-MAT-10000001 Project template
             </a>
         </h2>
         <p class="app-c-attachment__metadata">


### PR DESCRIPTION
- update heading structure for the reference names to h4 so that it follows the h3 from the one above reference names
-  updated the application-card css to accommodate full width on mobile
-  updated project template name to say [reference number Project template] 